### PR TITLE
Add configurable BrickLink REST HTTP diagnostics

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <version>${lombok.version}</version>

--- a/src/main/java/com/bricklink/api/rest/configuration/BricklinkRestConfiguration.java
+++ b/src/main/java/com/bricklink/api/rest/configuration/BricklinkRestConfiguration.java
@@ -5,18 +5,23 @@ import com.bricklink.api.rest.client.BricklinkRestClient;
 import com.bricklink.api.rest.client.DefaultBricklinkRestClient;
 import com.bricklink.api.rest.exception.BricklinkClientException;
 import com.bricklink.api.rest.exception.BricklinkServerException;
+import com.bricklink.api.rest.support.BricklinkHttpLoggingInterceptor;
 import com.bricklink.api.rest.support.BricklinkOAuthInterceptor;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Primary;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatusCode;
+import org.springframework.http.client.BufferingClientHttpRequestFactory;
 import org.springframework.http.client.ClientHttpRequestInterceptor;
 import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.util.StreamUtils;
 import org.springframework.web.client.RestClient;
@@ -27,11 +32,10 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 
 @Configuration
+@EnableConfigurationProperties(BricklinkRestProperties.class)
 public class BricklinkRestConfiguration {
 
-    @Bean
-    @Primary
-    public ObjectMapper objectMapper() {
+    private ObjectMapper bricklinkRestObjectMapper() {
         ObjectMapper mapper = new ObjectMapper();
         mapper.registerModule(new JavaTimeModule());
         mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
@@ -47,27 +51,42 @@ public class BricklinkRestConfiguration {
 
     @Bean
     public RestClient bricklinkRestClientDelegate(
-            ObjectMapper mapper,
             BricklinkRestProperties bricklinkRestProperties,
-            ClientHttpRequestInterceptor bricklinkOAuthInterceptor) {
-        return RestClient.builder()
-                         .baseUrl(bricklinkRestProperties.getUri().toString())
-                         .messageConverters(converters -> {
-                             converters.removeIf(MappingJackson2HttpMessageConverter.class::isInstance);
-                             converters.add(new MappingJackson2HttpMessageConverter(mapper));
-                         })
-                         .requestInterceptor(bricklinkOAuthInterceptor)
-                         .defaultStatusHandler(HttpStatusCode::isError, (request, response) -> {
-                             int statusCode = response.getStatusCode().value();
-                             String body = responseBody(response);
-                             if (statusCode >= 400 && statusCode <= 499) {
-                                 throw new BricklinkClientException(statusCode, request.getMethod() + " " + request.getURI(), body);
-                             }
-                             if (statusCode >= 500 && statusCode <= 599) {
-                                 throw new BricklinkServerException(statusCode, "Bricklink server error response: [%s]".formatted(body));
-                             }
-                         })
-                         .build();
+            @Qualifier("bricklinkOAuthInterceptor") ClientHttpRequestInterceptor bricklinkOAuthInterceptor) {
+        RestClient.Builder builder = RestClient.builder()
+                .baseUrl(bricklinkRestProperties.getUri().toString())
+                .messageConverters(converters -> {
+                    converters.removeIf(MappingJackson2HttpMessageConverter.class::isInstance);
+                    converters.add(new MappingJackson2HttpMessageConverter(bricklinkRestObjectMapper()));
+                })
+                .requestInterceptor(bricklinkOAuthInterceptor)
+                .defaultStatusHandler(statusCode -> !statusCode.is2xxSuccessful(), (request, response) -> {
+                    int statusCode = response.getStatusCode().value();
+                    String body = responseBody(response);
+                    if (statusCode >= 300 && statusCode <= 399) {
+                        throw new BricklinkClientException(
+                                statusCode,
+                                request.getMethod() + " " + request.getURI(),
+                                "Unexpected redirect to [%s]. Response body: [%s]".formatted(
+                                        response.getHeaders().getFirst(HttpHeaders.LOCATION),
+                                        body
+                                )
+                        );
+                    }
+                    if (statusCode >= 400 && statusCode <= 499) {
+                        throw new BricklinkClientException(statusCode, request.getMethod() + " " + request.getURI(), body);
+                    }
+                    if (statusCode >= 500 && statusCode <= 599) {
+                        throw new BricklinkServerException(statusCode, "Bricklink server error response: [%s]".formatted(body));
+                    }
+                });
+
+        if (bricklinkRestProperties.getHttpLogging().isEnabled()) {
+            builder.requestFactory(new BufferingClientHttpRequestFactory(new SimpleClientHttpRequestFactory()));
+            builder.requestInterceptor(new BricklinkHttpLoggingInterceptor(bricklinkRestProperties));
+        }
+
+        return builder.build();
     }
 
     @Bean

--- a/src/main/java/com/bricklink/api/rest/configuration/BricklinkRestProperties.java
+++ b/src/main/java/com/bricklink/api/rest/configuration/BricklinkRestProperties.java
@@ -4,18 +4,17 @@ import lombok.Data;
 import lombok.Getter;
 import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.context.annotation.Configuration;
 
 import java.net.URI;
 
 @Setter
 @Getter
-@Configuration
 @ConfigurationProperties(prefix = "bricklink.rest")
 public class BricklinkRestProperties {
     private URI uri;
     private Consumer consumer = new Consumer();
     private Token token = new Token();
+    private HttpLogging httpLogging = new HttpLogging();
 
     @Data
     public static class Consumer {
@@ -28,5 +27,12 @@ public class BricklinkRestProperties {
         private String value;
         private String secret;
     }
-}
 
+    @Data
+    public static class HttpLogging {
+        private boolean enabled = false;
+        private boolean includeHeaders = false;
+        private boolean includeBody = true;
+        private int maxBodyLength = -1;
+    }
+}

--- a/src/main/java/com/bricklink/api/rest/support/BricklinkHttpLoggingInterceptor.java
+++ b/src/main/java/com/bricklink/api/rest/support/BricklinkHttpLoggingInterceptor.java
@@ -1,0 +1,106 @@
+package com.bricklink.api.rest.support;
+
+import com.bricklink.api.rest.configuration.BricklinkRestProperties;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpRequest;
+import org.springframework.http.client.ClientHttpRequestExecution;
+import org.springframework.http.client.ClientHttpRequestInterceptor;
+import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.util.StreamUtils;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+@Slf4j
+@RequiredArgsConstructor
+public class BricklinkHttpLoggingInterceptor implements ClientHttpRequestInterceptor {
+    private static final Set<String> SENSITIVE_HEADERS = Set.of(
+            HttpHeaders.AUTHORIZATION.toLowerCase(),
+            HttpHeaders.COOKIE.toLowerCase(),
+            HttpHeaders.SET_COOKIE.toLowerCase()
+    );
+
+    private final BricklinkRestProperties properties;
+
+    @Override
+    public ClientHttpResponse intercept(
+            HttpRequest request,
+            byte[] body,
+            ClientHttpRequestExecution execution
+    ) throws IOException {
+        BricklinkRestProperties.HttpLogging httpLogging = properties.getHttpLogging();
+        if (!httpLogging.isEnabled() || !log.isDebugEnabled()) {
+            return execution.execute(request, body);
+        }
+
+        logRequest(request, body, httpLogging);
+        ClientHttpResponse response = execution.execute(request, body);
+        logResponse(request, response, httpLogging);
+        return response;
+    }
+
+    private void logRequest(
+            HttpRequest request,
+            byte[] body,
+            BricklinkRestProperties.HttpLogging httpLogging
+    ) {
+        log.debug(
+                "bricklink.rest.request method={} uri={} headers={} body={}",
+                request.getMethod(),
+                request.getURI(),
+                headers(request.getHeaders(), httpLogging),
+                body(body, httpLogging)
+        );
+    }
+
+    private void logResponse(
+            HttpRequest request,
+            ClientHttpResponse response,
+            BricklinkRestProperties.HttpLogging httpLogging
+    ) throws IOException {
+        log.debug(
+                "bricklink.rest.response method={} uri={} statusCode={} statusText={} headers={} body={}",
+                request.getMethod(),
+                request.getURI(),
+                response.getStatusCode().value(),
+                response.getStatusText(),
+                headers(response.getHeaders(), httpLogging),
+                body(StreamUtils.copyToByteArray(response.getBody()), httpLogging)
+        );
+    }
+
+    private Object headers(HttpHeaders headers, BricklinkRestProperties.HttpLogging httpLogging) {
+        if (!httpLogging.isIncludeHeaders()) {
+            return "[disabled]";
+        }
+        HttpHeaders redacted = new HttpHeaders();
+        for (Map.Entry<String, List<String>> entry : headers.entrySet()) {
+            if (SENSITIVE_HEADERS.contains(entry.getKey().toLowerCase())) {
+                redacted.put(entry.getKey(), List.of("[redacted]"));
+            } else {
+                redacted.put(entry.getKey(), entry.getValue());
+            }
+        }
+        return redacted;
+    }
+
+    private Object body(byte[] body, BricklinkRestProperties.HttpLogging httpLogging) {
+        if (!httpLogging.isIncludeBody()) {
+            return "[disabled]";
+        }
+        if (body == null || body.length == 0) {
+            return "";
+        }
+        String value = new String(body, StandardCharsets.UTF_8);
+        int maxBodyLength = httpLogging.getMaxBodyLength();
+        if (maxBodyLength < 0 || value.length() <= maxBodyLength) {
+            return value;
+        }
+        return value.substring(0, maxBodyLength) + "...[truncated]";
+    }
+}

--- a/src/test/java/com/bricklink/api/rest/client/BricklinkRestClientEndpointTest.java
+++ b/src/test/java/com/bricklink/api/rest/client/BricklinkRestClientEndpointTest.java
@@ -4,7 +4,6 @@ import com.bricklink.api.rest.model.v1.Category;
 import com.bricklink.api.rest.model.v1.Inventory;
 import com.bricklink.api.rest.model.v1.Item;
 import com.bricklink.api.rest.model.v1.PriceGuide;
-import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -18,7 +17,6 @@ import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static org.assertj.core.api.Assertions.assertThat;
 
-@WireMockTest(httpPort = 8080)
 class BricklinkRestClientEndpointTest extends BricklistRestClientTest {
 
     @Test

--- a/src/test/java/com/bricklink/api/rest/client/BricklistRestClientTest.java
+++ b/src/test/java/com/bricklink/api/rest/client/BricklistRestClientTest.java
@@ -8,20 +8,36 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.core.io.ClassPathResource;
-import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+
 @EnableConfigurationProperties(value = BricklinkRestProperties.class)
 @SpringJUnitConfig(classes = {BricklinkRestConfiguration.class})
-@TestPropertySource("classpath:bricklink-rest.properties")
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 @Slf4j
 public abstract class BricklistRestClientTest {
     @RegisterExtension
-    public WireMockExtension wireMockRule = WireMockExtension.newInstance().build();
+    static WireMockExtension wireMockRule = WireMockExtension.newInstance()
+            .options(wireMockConfig().dynamicPort())
+            .configureStaticDsl(true)
+            .build();
+
+    @DynamicPropertySource
+    static void bricklinkRestProperties(DynamicPropertyRegistry registry) {
+        registry.add("bricklink.rest.uri", wireMockRule::baseUrl);
+        registry.add("bricklink.rest.consumer.key", () -> "0");
+        registry.add("bricklink.rest.consumer.secret", () -> "0");
+        registry.add("bricklink.rest.token.value", () -> "0");
+        registry.add("bricklink.rest.token.secret", () -> "0");
+    }
 
     @Autowired
     BricklinkRestClient bricklinkRestClient;

--- a/src/test/java/com/bricklink/api/rest/client/ColorTest.java
+++ b/src/test/java/com/bricklink/api/rest/client/ColorTest.java
@@ -1,7 +1,6 @@
 package com.bricklink.api.rest.client;
 
 import com.bricklink.api.rest.model.v1.Color;
-import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -16,7 +15,6 @@ import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
 import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static org.assertj.core.api.Assertions.assertThat;
 
-@WireMockTest(httpPort = 8080)
 class ColorTest extends BricklistRestClientTest {
     @Test
     void colorById_returns200() {

--- a/src/test/java/com/bricklink/api/rest/client/ErrorHandlingTest.java
+++ b/src/test/java/com/bricklink/api/rest/client/ErrorHandlingTest.java
@@ -2,7 +2,6 @@ package com.bricklink.api.rest.client;
 
 import com.bricklink.api.rest.exception.BricklinkClientException;
 import com.bricklink.api.rest.exception.BricklinkServerException;
-import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 import org.junit.jupiter.api.Test;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
@@ -11,7 +10,6 @@ import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static org.assertj.core.api.Assertions.assertThatCode;
 
-@WireMockTest(httpPort = 8080)
 class ErrorHandlingTest extends BricklistRestClientTest {
     @Test
     void invalidUri_returns() {
@@ -52,5 +50,22 @@ class ErrorHandlingTest extends BricklistRestClientTest {
         assertThatCode(() -> bricklinkRestClient.getColor(999))
                 .isInstanceOf(BricklinkServerException.class)
                 .hasMessageContaining("server failure");
+    }
+
+    @Test
+    void httpRedirect_throwsBricklinkClientException() {
+        stubFor(get(urlEqualTo("/orders?direction=in&status=PENDING"))
+                .willReturn(aResponse()
+                        .withStatus(302)
+                        .withHeader("Location", "http://api.bricklink.com/v2/error_404.page")));
+
+        assertThatCode(() -> bricklinkRestClient.getOrders(
+                java.util.Map.of("direction", "in"),
+                java.util.List.of("PENDING")
+        ))
+                .isInstanceOf(BricklinkClientException.class)
+                .hasMessageContaining("302")
+                .hasMessageContaining("Unexpected redirect")
+                .hasMessageContaining("error_404.page");
     }
 }

--- a/src/test/java/com/bricklink/api/rest/configuration/BricklinkRestConfigurationTest.java
+++ b/src/test/java/com/bricklink/api/rest/configuration/BricklinkRestConfigurationTest.java
@@ -1,0 +1,53 @@
+package com.bricklink.api.rest.configuration;
+
+import com.bricklink.api.rest.client.BricklinkRestClient;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class BricklinkRestConfigurationTest {
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withUserConfiguration(
+                    ApplicationObjectMapperConfiguration.class,
+                    BricklinkRestConfiguration.class
+            )
+            .withPropertyValues(
+                    "bricklink.rest.uri=https://api.bricklink.com/api/store/v1",
+                    "bricklink.rest.consumer.key=consumer-key",
+                    "bricklink.rest.consumer.secret=consumer-secret",
+                    "bricklink.rest.token.value=token-value",
+                    "bricklink.rest.token.secret=token-secret"
+            );
+
+    @Test
+    void startsAlongsideApplicationObjectMapperWithoutPublishingAGlobalMapper() {
+        contextRunner.run(context -> {
+            assertThat(context).hasNotFailed();
+            assertThat(context).hasSingleBean(BricklinkRestClient.class);
+            assertThat(context).hasBean("objectMapper");
+            assertThat(context.getBeansOfType(ObjectMapper.class)).containsOnlyKeys("objectMapper");
+        });
+    }
+
+    @Test
+    void startsWithHttpLoggingEnabled() {
+        contextRunner
+                .withPropertyValues("bricklink.rest.http-logging.enabled=true")
+                .run(context -> {
+                    assertThat(context).hasNotFailed();
+                    assertThat(context).hasSingleBean(BricklinkRestClient.class);
+                });
+    }
+
+    @Configuration
+    static class ApplicationObjectMapperConfiguration {
+        @Bean
+        ObjectMapper objectMapper() {
+            return new ObjectMapper();
+        }
+    }
+}

--- a/src/test/java/com/bricklink/api/rest/support/BricklinkHttpLoggingInterceptorTest.java
+++ b/src/test/java/com/bricklink/api/rest/support/BricklinkHttpLoggingInterceptorTest.java
@@ -1,0 +1,88 @@
+package com.bricklink.api.rest.support;
+
+import com.bricklink.api.rest.configuration.BricklinkRestProperties;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.client.ClientHttpResponse;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class BricklinkHttpLoggingInterceptorTest {
+    @Test
+    void disabledLoggingDoesNotConsumeResponseBody() throws IOException {
+        BricklinkRestProperties properties = new BricklinkRestProperties();
+        BricklinkHttpLoggingInterceptor interceptor = new BricklinkHttpLoggingInterceptor(properties);
+        TestResponse response = new TestResponse("{\"meta\":{\"code\":200}}");
+
+        ClientHttpResponse intercepted = interceptor.intercept(
+                new TestRequest(),
+                new byte[0],
+                (request, body) -> response
+        );
+
+        assertThat(new String(intercepted.getBody().readAllBytes())).isEqualTo("{\"meta\":{\"code\":200}}");
+    }
+
+    private static class TestRequest implements HttpRequest {
+        @Override
+        public HttpMethod getMethod() {
+            return HttpMethod.GET;
+        }
+
+        @Override
+        public URI getURI() {
+            return URI.create("https://api.bricklink.com/api/store/v1/orders");
+        }
+
+        @Override
+        public HttpHeaders getHeaders() {
+            return new HttpHeaders();
+        }
+
+        @Override
+        public Map<String, Object> getAttributes() {
+            return Map.of();
+        }
+    }
+
+    private static class TestResponse implements ClientHttpResponse {
+        private final byte[] body;
+
+        private TestResponse(String body) {
+            this.body = body.getBytes();
+        }
+
+        @Override
+        public HttpStatus getStatusCode() {
+            return HttpStatus.OK;
+        }
+
+        @Override
+        public String getStatusText() {
+            return "OK";
+        }
+
+        @Override
+        public void close() {
+        }
+
+        @Override
+        public InputStream getBody() {
+            return new ByteArrayInputStream(body);
+        }
+
+        @Override
+        public HttpHeaders getHeaders() {
+            return new HttpHeaders();
+        }
+    }
+}

--- a/src/test/resources/bricklink-rest.properties
+++ b/src/test/resources/bricklink-rest.properties
@@ -1,4 +1,3 @@
-bricklink.rest.uri=http://localhost:8080/
 bricklink.rest.consumer.key=0
 bricklink.rest.consumer.secret=0
 bricklink.rest.token.value=0


### PR DESCRIPTION
## Summary
- Add `bricklink.rest.http-logging` configuration for optional DEBUG request/response diagnostics.
- Add a redacting `BricklinkHttpLoggingInterceptor` that can log headers and bodies when explicitly enabled.
- Keep the BrickLink REST `ObjectMapper` internal to the client configuration to avoid app-level `objectMapper` bean collisions.
- Fail fast for any non-2xx HTTP response, including redirects, so bad base URLs surface as explicit client errors.
- Convert WireMock tests to dynamic ports and add focused coverage for configuration, logging, and redirect handling.

## Verification
- `mvn test`
- 15 tests passing, 0 failures/errors

## Notes
- Header logging remains opt-in and redacts Authorization/Cookie/Set-Cookie.
- Body logging remains opt-in via `bricklink.rest.http-logging.enabled` and DEBUG logger level.