### PR TITLE
Validate BrickLink OAuth configuration

### DIFF
--- a/src/main/java/com/bricklink/api/rest/client/DefaultBricklinkRestClient.java
+++ b/src/main/java/com/bricklink/api/rest/client/DefaultBricklinkRestClient.java
@@ -132,6 +132,15 @@ public class DefaultBricklinkRestClient implements BricklinkRestClient {
     }
 
     private Map<String, Object> nonNullParams(Map<String, Object> params) {
-        return params == null ? new HashMap<>() : new HashMap<>(params);
+        Map<String, Object> nonNullParams = new HashMap<>();
+        if (params == null) {
+            return nonNullParams;
+        }
+        params.forEach((key, value) -> {
+            if (key != null && value != null) {
+                nonNullParams.put(key, value);
+            }
+        });
+        return nonNullParams;
     }
 }

--- a/src/main/java/com/bricklink/api/rest/support/BricklinkOAuthInterceptor.java
+++ b/src/main/java/com/bricklink/api/rest/support/BricklinkOAuthInterceptor.java
@@ -7,6 +7,7 @@ import org.springframework.http.client.ClientHttpRequestExecution;
 import org.springframework.http.client.ClientHttpRequestInterceptor;
 import org.springframework.http.client.ClientHttpResponse;
 import org.springframework.util.MultiValueMap;
+import org.springframework.util.StringUtils;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import java.io.IOException;
@@ -20,6 +21,7 @@ public class BricklinkOAuthInterceptor implements ClientHttpRequestInterceptor {
 
     public BricklinkOAuthInterceptor(BricklinkRestProperties properties) {
         this.properties = properties;
+        validateProperties(properties);
     }
 
     @Override
@@ -50,5 +52,30 @@ public class BricklinkOAuthInterceptor implements ClientHttpRequestInterceptor {
                 oauthParameters.get(OAuthConstants.SIGNATURE),
                 oauthParameters.get(OAuthConstants.TIMESTAMP),
                 oauthParameters.get(OAuthConstants.NONCE));
+    }
+
+    private void validateProperties(BricklinkRestProperties properties) {
+        requireText(
+                properties.getConsumer() == null ? null : properties.getConsumer().getKey(),
+                "bricklink.rest.consumer.key"
+        );
+        requireText(
+                properties.getConsumer() == null ? null : properties.getConsumer().getSecret(),
+                "bricklink.rest.consumer.secret"
+        );
+        requireText(
+                properties.getToken() == null ? null : properties.getToken().getValue(),
+                "bricklink.rest.token.value"
+        );
+        requireText(
+                properties.getToken() == null ? null : properties.getToken().getSecret(),
+                "bricklink.rest.token.secret"
+        );
+    }
+
+    private void requireText(String value, String propertyName) {
+        if (!StringUtils.hasText(value)) {
+            throw new IllegalStateException("Missing required BrickLink REST property [%s]".formatted(propertyName));
+        }
     }
 }

--- a/src/test/java/com/bricklink/api/rest/client/ErrorHandlingTest.java
+++ b/src/test/java/com/bricklink/api/rest/client/ErrorHandlingTest.java
@@ -4,6 +4,10 @@ import com.bricklink.api.rest.exception.BricklinkClientException;
 import com.bricklink.api.rest.exception.BricklinkServerException;
 import org.junit.jupiter.api.Test;
 
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
@@ -67,5 +71,21 @@ class ErrorHandlingTest extends BricklistRestClientTest {
                 .hasMessageContaining("302")
                 .hasMessageContaining("Unexpected redirect")
                 .hasMessageContaining("error_404.page");
+    }
+
+    @Test
+    void getOrdersFiltersNullRequestParametersBeforeSigning() {
+        stubFor(get(urlEqualTo("/orders?direction=in&status=PENDING"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"meta\":{\"code\":200},\"data\":[]}")));
+
+        Map<String, Object> params = new HashMap<>();
+        params.put("direction", "in");
+        params.put("filed", null);
+
+        assertThatCode(() -> bricklinkRestClient.getOrders(params, List.of("PENDING")))
+                .doesNotThrowAnyException();
     }
 }

--- a/src/test/java/com/bricklink/api/rest/configuration/BricklinkRestConfigurationTest.java
+++ b/src/test/java/com/bricklink/api/rest/configuration/BricklinkRestConfigurationTest.java
@@ -43,6 +43,20 @@ class BricklinkRestConfigurationTest {
                 });
     }
 
+    @Test
+    void failsWithClearMessageWhenOAuthPropertiesAreMissing() {
+        new ApplicationContextRunner()
+                .withUserConfiguration(BricklinkRestConfiguration.class)
+                .withPropertyValues("bricklink.rest.uri=https://api.bricklink.com/api/store/v1")
+                .run(context -> {
+                    assertThat(context).hasFailed();
+                    assertThat(context.getStartupFailure())
+                            .rootCause()
+                            .isInstanceOf(IllegalStateException.class)
+                            .hasMessageContaining("Missing required BrickLink REST property [bricklink.rest.consumer.key]");
+                });
+    }
+
     @Configuration
     static class ApplicationObjectMapperConfiguration {
         @Bean


### PR DESCRIPTION
## Summary
- fail fast when required bricklink.rest OAuth properties are missing
- avoid NullPointerException from BLAuthSigner when deployment config is misnested
- filter null request parameters before building order-list requests

## Production finding
The services-sandbox pod has /etc/.credentials/bricklink-client-api-keys.yml shaped as bricklink.consumer/token, but bricklink-rest binds bricklink.rest.consumer/token. That leaves the OAuth signer values null and causes the observed Unable to sign BrickLink request failure.

## Verification
- mvn clean install