### PR TITLE
Fix BrickLink OAuth signature normalization

### DIFF
--- a/src/main/java/com/bricklink/api/rest/support/BLAuthSigner.java
+++ b/src/main/java/com/bricklink/api/rest/support/BLAuthSigner.java
@@ -3,13 +3,14 @@ package com.bricklink.api.rest.support;
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
 import java.io.UnsupportedEncodingException;
+import java.net.URI;
 import java.net.URLEncoder;
 import java.util.Base64;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
+import java.util.AbstractMap.SimpleImmutableEntry;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 // @See https://medium.com/@prasad.veluru/guide-to-authenticate-requests-using-oauth-1-0-231e4894311f
 public class BLAuthSigner {
@@ -29,7 +30,7 @@ public class BLAuthSigner {
 	private String				verb;
 
 	private Map<String, String>	oauthParameters;
-	private Map<String, String>	queryParameters;
+	private List<Map.Entry<String, String>> queryParameters;
 
 	private Timer				timer;
 
@@ -41,7 +42,7 @@ public class BLAuthSigner {
 		this.consumerKey = consumerKey;
 		this.consumerSecret = consumerSecret;
 		this.oauthParameters = new HashMap<>();
-		this.queryParameters = new HashMap<>();
+		this.queryParameters = new ArrayList<>();
 		this.timer = timer;
 	}
 
@@ -59,7 +60,7 @@ public class BLAuthSigner {
 	}
 
 	public void addParameter( String key, String value ) {
-		queryParameters.put( key, value );
+		queryParameters.add( new SimpleImmutableEntry<>(key, value) );
 	}
 
 	public Map<String, String> getFinalOAuthParams( ) throws Exception {
@@ -97,28 +98,42 @@ public class BLAuthSigner {
 	}
 
 	private String getNonce( ) {
-		Long ts = timer.getMilis();
-		return String.valueOf( ts + Math.abs( timer.getRandomInteger() ) );
+		return timer.getNonce();
 	}
 
 
 	private String getBaseString( ) {
-		String params = Stream.of(oauthParameters, queryParameters)
-				.map(Map::entrySet)
-				.flatMap(Collection::stream)
-				.collect(Collectors.toMap(
-						Map.Entry::getKey,
-						Map.Entry::getValue, (k1, k2) -> k1))
-				.entrySet()
+		List<Map.Entry<String, String>> parameters = new ArrayList<>();
+		parameters.addAll(oauthParameters.entrySet());
+		parameters.addAll(queryParameters);
+
+		String params = parameters
 				.stream()
-				.map(e -> OAuthEncoder.encode( e.getKey() ).concat( "=" ).concat( e.getValue() ))
-				.sorted()
+				.map(e -> new SimpleImmutableEntry<>(
+						OAuthEncoder.encode( e.getKey() ),
+						OAuthEncoder.encode( e.getValue() )))
+				.sorted(Comparator.comparing(Map.Entry<String, String>::getKey)
+						.thenComparing(Map.Entry::getValue))
+				.map(e -> e.getKey().concat( "=" ).concat( e.getValue() ))
 				.collect(Collectors.joining("&"));
 
 		String formUrlEncodedParams = OAuthEncoder.encode(params);
-		String sanitizedURL = OAuthEncoder.encode( url.replaceAll( "\\?.*", "" ).replace( "\\:\\d{4}", "" ) );
+		String sanitizedURL = OAuthEncoder.encode(getBaseUrl());
 
 		return  "%s&%s&%s".formatted(verb, sanitizedURL, formUrlEncodedParams);
+	}
+
+	private String getBaseUrl() {
+		URI uri = URI.create(url);
+		String scheme = uri.getScheme().toLowerCase(Locale.ROOT);
+		String host = uri.getHost().toLowerCase(Locale.ROOT);
+		String path = uri.getRawPath();
+		int port = uri.getPort();
+		boolean includePort = port != -1
+				&& !("http".equals(scheme) && port == 80)
+				&& !("https".equals(scheme) && port == 443);
+
+		return scheme + "://" + host + (includePort ? ":" + port : "") + (path == null || path.isBlank() ? "/" : path);
 	}
 
 	private String doSign( String toSign, String keyString ) throws Exception {
@@ -142,6 +157,11 @@ public class BLAuthSigner {
 
 		public Integer getRandomInteger( ) {
 			return rand.nextInt();
+		}
+
+		public String getNonce() {
+			Long ts = getMilis();
+			return String.valueOf( ts + Math.abs( getRandomInteger() ) );
 		}
 	}
 

--- a/src/main/java/com/bricklink/api/rest/support/BricklinkOAuthInterceptor.java
+++ b/src/main/java/com/bricklink/api/rest/support/BricklinkOAuthInterceptor.java
@@ -34,7 +34,7 @@ public class BricklinkOAuthInterceptor implements ClientHttpRequestInterceptor {
         MultiValueMap<String, String> queryParams = UriComponentsBuilder.fromUri(request.getURI())
                                                                          .build()
                                                                          .getQueryParams();
-        queryParams.forEach((key, values) -> signer.addParameter(key, String.join(",", values)));
+        queryParams.forEach((key, values) -> values.forEach(value -> signer.addParameter(key, value)));
 
         try {
             request.getHeaders().set(HttpHeaders.AUTHORIZATION, getAuthorizationHeader(signer.getFinalOAuthParams()));

--- a/src/test/java/com/bricklink/api/rest/support/BLAuthSignerTest.java
+++ b/src/test/java/com/bricklink/api/rest/support/BLAuthSignerTest.java
@@ -1,0 +1,68 @@
+package com.bricklink.api.rest.support;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class BLAuthSignerTest {
+    @Test
+    void signsOAuthSpecificationExample() throws Exception {
+        BLAuthSigner signer = new BLAuthSigner(
+                "dpf43f3p2l4k3l03",
+                "kd94hf93k423kf44",
+                new StaticTimer(1191242096000L, "kllo9940pd9333jh")
+        );
+        signer.setToken("nnch734d00sl2jdk", "pfkkdhi9sl3r4s00");
+        signer.setVerb("GET");
+        signer.setURL("http://photos.example.net/photos?file=vacation.jpg&size=original");
+        signer.addParameter("file", "vacation.jpg");
+        signer.addParameter("size", "original");
+
+        Map<String, String> oauthParams = signer.getFinalOAuthParams();
+
+        assertThat(oauthParams.get(OAuthConstants.SIGNATURE))
+                .isEqualTo("tR3%2BTy81lMeYAr%2FFid0kMTYa%2FWM%3D");
+    }
+
+    @Test
+    void signsRepeatedQueryParametersAsSeparatePairs() throws Exception {
+        BLAuthSigner signer = new BLAuthSigner(
+                "consumer-key",
+                "consumer-secret",
+                new StaticTimer(1700000000000L, "nonce")
+        );
+        signer.setToken("token-value", "token-secret");
+        signer.setVerb("GET");
+        signer.setURL("https://api.bricklink.com/api/store/v1/orders?direction=in&status=PENDING&status=UPDATED");
+        signer.addParameter("direction", "in");
+        signer.addParameter("status", "PENDING");
+        signer.addParameter("status", "UPDATED");
+
+        Map<String, String> oauthParams = signer.getFinalOAuthParams();
+
+        assertThat(oauthParams.get(OAuthConstants.SIGNATURE))
+                .isEqualTo("yNDjeTFN7Ba%2BiLg3bhPGSmu7tng%3D");
+    }
+
+    private static class StaticTimer extends BLAuthSigner.Timer {
+        private final long millis;
+        private final String nonce;
+
+        private StaticTimer(long millis, String nonce) {
+            this.millis = millis;
+            this.nonce = nonce;
+        }
+
+        @Override
+        public Long getMilis() {
+            return millis;
+        }
+
+        @Override
+        public String getNonce() {
+            return nonce;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Preserve repeated query parameters when constructing BrickLink OAuth signatures
- Percent-encode OAuth parameter names and values before sorting/signing
- Normalize the request base URL using URI components instead of regex replacement
- Add deterministic signer coverage for the OAuth 1.0 spec example and repeated BrickLink order status parameters

## Context
The Kubernetes deployment now starts with the corrected secret shape, but BrickLink returns 401 BAD_OAUTH_REQUEST / SIGNATURE_INVALID for the open-order probe. The failing call signs /orders with multiple status query parameters. The previous signer collapsed repeated parameters into one comma-joined value, so the OAuth base string did not match the actual request BrickLink receives.

## Verification
- mvn clean install
- Tests run: 19, Failures: 0, Errors: 0, Skipped: 0