### PR TITLE
Clean up bricklink-rest test build warnings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,10 +15,9 @@
     <name>Bricklink API :: REST</name>
 
     <properties>
-        <mockito.version>5.3.1</mockito.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>21</java.version>
-        <lombok.version>1.18.42</lombok.version>
+        <lombok.version>1.18.46</lombok.version>
         <maven-compiler-plugin.version>3.14.1</maven-compiler-plugin.version>
         <github.organization>LegoHunter</github.organization>
         <bricklink-api-model.version>1.3.0-SNAPSHOT</bricklink-api-model.version>
@@ -104,15 +103,19 @@
         </dependency>
 
         <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.mockito</groupId>
+                    <artifactId>mockito-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.mockito</groupId>
+                    <artifactId>mockito-junit-jupiter</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -124,7 +127,7 @@
         <dependency>
             <groupId>org.wiremock</groupId>
             <artifactId>wiremock-standalone</artifactId>
-            <version>3.2.0</version>
+            <version>3.13.2</version>
             <scope>test</scope>
         </dependency>
 

--- a/src/test/java/com/bricklink/api/rest/service/ColorServiceTest.java
+++ b/src/test/java/com/bricklink/api/rest/service/ColorServiceTest.java
@@ -6,20 +6,16 @@ import com.bricklink.api.rest.model.v1.BricklinkResource;
 import com.bricklink.api.rest.model.v1.Color;
 import org.junit.jupiter.api.Test;
 
+import java.lang.reflect.Proxy;
 import java.util.ArrayList;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.mock;
 
 class ColorServiceTest {
     @Test
     void colorById() {
-        BricklinkRestClient bricklinkRestClient = mock(BricklinkRestClient.class);
-        setupColorsList(bricklinkRestClient);
-        BricklinkResource<Color> color = getResource(200, color(1, "1", "White"));
-        doReturn(color).when(bricklinkRestClient).getColor(1);
+        BricklinkRestClient bricklinkRestClient = stubClient();
         ColorService colorService = new ColorService(bricklinkRestClient);
         Color c = colorService.getColorById(1);
         Color c1 = colorService.getColorByName("White");
@@ -48,7 +44,7 @@ class ColorServiceTest {
         return resource;
     }
 
-    private void setupColorsList(final BricklinkRestClient bricklinkRestClient) {
+    private BricklinkRestClient stubClient() {
         List<Color> colors = new ArrayList<>();
         colors.add(color(1, "1", "White"));
         colors.add(color(2, "2", "Tan"));
@@ -56,6 +52,17 @@ class ColorServiceTest {
         colors.add(color(4, "4", "Orange"));
         colors.add(color(5, "5", "Red"));
         colors.add(color(6, "6", "Reddish-Brown"));
-        doReturn(getResource(200, colors)).when(bricklinkRestClient).getColors();
+        BricklinkResource<List<Color>> colorsResource = getResource(200, colors);
+
+        return (BricklinkRestClient) Proxy.newProxyInstance(
+                BricklinkRestClient.class.getClassLoader(),
+                new Class<?>[]{BricklinkRestClient.class},
+                (proxy, method, args) -> {
+                    if ("getColors".equals(method.getName())) {
+                        return colorsResource;
+                    }
+                    throw new UnsupportedOperationException(method.getName());
+                }
+        );
     }
 }


### PR DESCRIPTION
## Summary
- Upgrade WireMock standalone from 3.2.0 to 3.13.2 to remove SLF4J 1.7 binding warnings with the Spring Boot SLF4J 2.x stack.
- Remove the remaining Mockito-based test stub and exclude Mockito from the test starter to avoid ByteBuddy dynamic-agent warnings on newer JDKs.
- Bump Lombok to 1.18.46 and keep ColorService coverage via a small JDK proxy stub.

## Verification
- mvn clean install

## Notes
- The original BrickLink OAuth 401 was traced to incorrect TokenValue/TokenSecret values, not a signing-code defect. This PR intentionally contains only test/build warning cleanup.